### PR TITLE
fix: storyblok components not re-rendering when navigating across pages

### DIFF
--- a/src/components/blog-components/StoryblokContainer.tsx
+++ b/src/components/blog-components/StoryblokContainer.tsx
@@ -3,11 +3,12 @@ import { useEffect } from "react";
 
 interface StoryblokContainerProps {
     storyContent: any;
+    keyID: any;
 }
 
 const StoryblokContainer = (props: StoryblokContainerProps) => {
     return (
-        <StoryblokComponent blok={props.storyContent}/>
+        <StoryblokComponent blok={props.storyContent} key={props.keyID}/>
     );
 }
 

--- a/src/components/storyblok-components/AllArticles.tsx
+++ b/src/components/storyblok-components/AllArticles.tsx
@@ -24,9 +24,9 @@ const AllArticles = ({ blok }: any) => {
           is_startpage: false
         });
   
-        setArticles((prev) => data.stories.map((Article: any) => {
-          Article.content.slug = Article.slug;
-          return Article;
+        setArticles((prev) => data.stories.map((article: any) => {
+          article.content.slug = article.slug;
+          return article;
         }));
         setIsLoading(false);
     };
@@ -34,7 +34,7 @@ const AllArticles = ({ blok }: any) => {
   }, []);
 
   return (
-    <section className="w-full flex items-center justify-center max-w-screen-xl">
+    <section className="w-full flex items-center justify-center max-w-screen-xl" key={blok.uuid}>
       <div className="w-full flex justify-center">
         <div className="article-container flex flex-col gap-y-8 xl:flex-row">
           {isLoading ? (
@@ -47,12 +47,12 @@ const AllArticles = ({ blok }: any) => {
           ) : (
             <div className="flex flex-col items-center justify-center gap-y-8">
               <div {...storyblokEditable(blok)} className="hidden xl:flex w-full items-center justify-center">
-                {blok && articles[0] && <NewestArticleTeaser Article={articles[0]}/>}
+                {blok && articles[0] && <NewestArticleTeaser article={articles[0]}/>}
               </div>
               <div {...storyblokEditable(blok)}
                 className="w-full flex flex-col xl:flex-row items-center justify-center">
-                {blok && articles[0] && articles.map((Article: any) => (
-                  <ArticleTeaser Article={Article.content} key={Article.uuid} />
+                {blok && articles[0] && articles.map((article: any) => (
+                  <ArticleTeaser article={article.content} key={article.uuid} />
                   ))}
               </div>
             </div>

--- a/src/components/storyblok-components/ArticleTeaser.tsx
+++ b/src/components/storyblok-components/ArticleTeaser.tsx
@@ -1,16 +1,16 @@
 import Link from "next/link";
 
-const ArticleTeaser = ({ Article }: any) => {
+const ArticleTeaser = ({ article }: any) => {
   return (
-    <section className="w-full py-2 h-full">
+    <section className="w-full py-2 h-full" key={article.uuid}>
       <div className="w-full px-4 h-full">
-        <Link href={`/blog/${Article.slug}`}>
+        <Link href={`/blog/${article.slug}`}>
           <a className="w-full flex flex-col items-center h-full">
             <div className="flex w-full">
-              <img src={Article.image.filename} alt="blog" className="w-full aspect-video object-cover rounded-t-xl"/>
+              <img src={article.image.filename} alt="blog" className="w-full aspect-video object-cover rounded-t-xl"/>
             </div>
             <div className="h-1/2 flex flex-col w-full px-6 py-12 gap-y-6 bg-[#222530] rounded-b-xl flex-grow justify-between">
-              <h1 className="flex self-start w-full text-xl">{Article.title}</h1>
+              <h1 className="flex self-start w-full text-xl">{article.title}</h1>
               <div className="flex w-full justify-between items-center">
                 <span className="text-sm text-[#7C7F8B]">Model Engineer</span>
                 <img src="/assets/simlai/arrow-blog-teaser.svg"></img>

--- a/src/components/storyblok-components/Feature.tsx
+++ b/src/components/storyblok-components/Feature.tsx
@@ -2,7 +2,7 @@ import { storyblokEditable } from "@storyblok/react";
 import { FeatureStoryblok } from "../../../component-types-sb";
  
 const Feature = ({ blok }: FeatureStoryblok) => (
-  <div className="column feature" {...storyblokEditable(blok)}>
+  <div className="column feature" {...storyblokEditable(blok)} key={blok._uid}>
     {blok.name}
   </div>
 );

--- a/src/components/storyblok-components/Grid.tsx
+++ b/src/components/storyblok-components/Grid.tsx
@@ -3,7 +3,7 @@ import { GridStoryblok } from "../../../component-types-sb";
  
 const Grid = ({ blok }: GridStoryblok) => {
   return (
-    <div className="grid" {...storyblokEditable(blok)}>
+    <div className="grid" {...storyblokEditable(blok)} key={blok._uid}>
       {blok.columns.map((nestedBlok: any) => (
         <StoryblokComponent blok={nestedBlok} key={nestedBlok._uid} />
       ))}

--- a/src/components/storyblok-components/NewestArticleTeaser.tsx
+++ b/src/components/storyblok-components/NewestArticleTeaser.tsx
@@ -1,16 +1,16 @@
 import Link from "next/link";
 
-const NewestArticleTeaser = ( { Article }: any) => {
+const NewestArticleTeaser = ( { article }: any) => {
     return (
-        <section className="w-full">
-            <Link href={`/blog/${Article.content.slug}`}>
+        <section className="w-full" key={article.uuid}>
+            <Link href={`/blog/${article.content.slug}`}>
                 <a>
                     <article className="flex flex-row">
                         <div className="w-3/4 overflow-hidden flex">
-                            <img src={Article.content.image.filename} alt={Article.content.image.alt} className="rounded-l-xl object-cover aspect-video w-full"/>
+                            <img src={article.content.image.filename} alt={article.content.image.alt} className="rounded-l-xl object-cover aspect-video w-full"/>
                         </div>
                         <div className="flex flex-col w-1/4 px-6 py-12 gap-y-6 bg-[#222530] rounded-r-xl justify-between">
-                            <h1 className="flex self-start w-full text-xl">{Article.content.title}</h1>
+                            <h1 className="flex self-start w-full text-xl">{article.content.title}</h1>
                             <div className="flex w-full justify-between items-center">
                                 <span className="text-sm text-[#7C7F8B]">Model Engineer</span>
                                 <img src="/assets/simlai/arrow-blog-teaser.svg"></img>

--- a/src/components/storyblok-components/Page.tsx
+++ b/src/components/storyblok-components/Page.tsx
@@ -2,7 +2,7 @@ import { storyblokEditable, StoryblokComponent } from "@storyblok/react";
 import { PageStoryblok } from "../../../component-types-sb";
  
 const Page = ({ blok }: PageStoryblok) => (
-  <main {...storyblokEditable(blok)}>
+  <main {...storyblokEditable(blok)} key={blok.uuid}>
     {blok.body && blok.body.map((nestedBlok: any) => (
       <StoryblokComponent blok={nestedBlok} key={nestedBlok._uid} />
     ))}

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -16,15 +16,18 @@ import Article from '@/components/storyblok-components/Article';
 import Header from '../components/homepage/Header';
 import Footer from '@/components/homepage/Footer';
 import { GetStaticPropsContext } from 'next';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import DropdownMenu from '@/components/homepage/main-components/mobile-components/DropdownMenu';
+import Page from '@/components/storyblok-components/Page';
+import AllArticles from '@/components/storyblok-components/AllArticles';
 
 const components = {
   feature: Feature,
   grid: Grid,
   teaser: Teaser,
   page: Page,
-  Article: Article,
+  article: Article,
+  'all-articles': AllArticles,
 };
 
 storyblokInit({
@@ -35,10 +38,12 @@ storyblokInit({
 
 interface PageProps {
   story: StoryData<any>;
+  keyID: any;
 }
 
-export default function Page({ story  }: PageProps) {
+export default function BlogPost({ story, keyID }: PageProps) {
   story = useStoryblokState(story);
+  
   const [isOpen, setIsOpen] = useState(true);
 
   const handleOpen = () => {
@@ -61,7 +66,7 @@ export default function Page({ story  }: PageProps) {
         {isOpen ? (
           <section className='w-full'>
             <Header open={!isOpen} onClose={handleOpen}/>
-            <StoryblokComponent blok={story.content} />
+            <StoryblokComponent blok={story.content} key={keyID}/>
             <Footer open={!isOpen}/>
           </section>
         ) : (
@@ -90,7 +95,7 @@ export async function getStaticProps({ params }: GetStaticPropsContext) {
   return {
     props: {
       story: data ? data.story : false,
-      key: data ? data.story.id : false,
+      keyID: data ? data.story.id : false,
     },
     revalidate: 3600,
   };

--- a/src/pages/blog.tsx
+++ b/src/pages/blog.tsx
@@ -1,4 +1,4 @@
-import { storyblokInit, apiPlugin, getStoryblokApi, StoryblokComponent, useStoryblokState } from "@storyblok/react";
+import { storyblokInit, apiPlugin, getStoryblokApi, StoryblokComponent, useStoryblokState, StoryData } from "@storyblok/react";
 import Feature from "../components/storyblok-components/Feature";
 import Page from "../components/storyblok-components/Page";
 import Grid from "../components/storyblok-components/Grid";
@@ -84,30 +84,23 @@ storyblokInit({
 });
 
 export default function Blog( props: any ) {
-  const story = useStoryblokState(props.story)
+  const sbStory = useStoryblokState(props.story)
+  const [story, setStory] = useState(sbStory);
 
   const [isOpen, setIsOpen] = useState(true);
 
   const handleOpen = () => {
     setIsOpen(prevIsOpen =>  {
-      // it reloads the whole page after close button in DropdownMenu is clicked
-      // fixes bug when opened and closed DropdownMenu it produced error "Please provide blok property to StoryblokComponent"
-      if(!prevIsOpen) {
-        window.location.reload();
-      }
-
       return !prevIsOpen;
     });
-
   }
-  
+
   useEffect(() => {
-    return () => {
-      window.onpopstate = function(event) {
-        window.location.reload();
-      };
-    };
-  }, []);
+    setStory(sbStory);
+
+    // return () => setStory()
+  }, [sbStory]);
+  
 
   return (
     <>
@@ -128,10 +121,9 @@ export default function Blog( props: any ) {
               <Search/>
               <div className="w-full py-4 pb-12 flex items-center justify-center">
                 <div className="flex lg:w-[80%] flex-wrap gap-y-4 py-12 justify-center">
-                  <StoryblokContainer storyContent={story.content}/>
+                  <StoryblokContainer storyContent={story.content} keyID={props.keyID}/>
                 </div>
               </div>
-
               <Footer open={!isOpen}/>
             </div>
             
@@ -156,7 +148,7 @@ export async function getServerSideProps() {
   return {
     props: {
       story: data ? data.story : null,
-      key: data ? data.story.id : null,
+      keyID: data ? data.story.id : null,
     },
     // revalidate: 3600,
   };


### PR DESCRIPTION
## What was wrong:

- component name on dynamic page was the same as storyblok component one's, this resulted in "recursive" render of `Page` component
- components didn't have `key` props